### PR TITLE
feat/apiCanBeMockedWithJSONObject

### DIFF
--- a/features/dev-http.feature
+++ b/features/dev-http.feature
@@ -37,3 +37,8 @@ Feature: Dev can intercept http requests
     Given _http mock for 'http://localhost:4200/fetch2' is 'example-fetch2'
     Given _user navigates to 'http://localhost:4200/fetch'
     Then _user sees '.fetched'
+
+  Scenario: Http call made by javascript fetch is intercepted with json response
+    Given _http mock for 'http://localhost:4200/fetch-json' is 'example-fetch-json'
+    Given _user navigates to 'http://localhost:4200/fetch-json'
+    Then _'<body' content should contain "John"

--- a/features/mocks/http/example-fetch-json.json
+++ b/features/mocks/http/example-fetch-json.json
@@ -1,0 +1,8 @@
+{
+  "response": {
+    "status": 200,
+    "headers": { "access-control-allow-origin": "*" },
+    "contentType": "text/html",
+    "body": "{ \"name\": \"John\", \"age\": 30 }"
+  }
+}


### PR DESCRIPTION
- **feat(httpMock): http mock works with query params**
- **feat(version): update to version 2.55.0 [ci skip]**
- **feat(httpMock): mock with a real object instead of stringified**
